### PR TITLE
Vector2D Fix

### DIFF
--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -136,7 +136,7 @@ void Serializer::writeVec2D(const Vector2D& vec)
 	if (sizeof(uint32_t) * 2 > size - offset)
 		setSize(size + sizeof(uint32_t) * 2 - size - offset);
 
-	memcpy(data, &((char*)&vec)[offsetof(Vector2D, x_)], sizeof(uint32_t));
+	memcpy(data, &((char*)&vec)[offsetof(Vector2D, x)], sizeof(uint32_t));
 
 	offset += sizeof(uint32_t) * 2;
 }
@@ -160,7 +160,7 @@ Vector2D Serializer::readVec2D()
 
 	Vector2D result;
 
-	memcpy(&((char*)&result)[offsetof(Vector2D, x_)], &data[offset], sizeof(uint32_t));
+	memcpy(&((char*)&result)[offsetof(Vector2D, x)], &data[offset], sizeof(uint32_t));
 
 	offset += sizeof(uint32_t) * 2;
 

--- a/src/StarshipAscension.cpp
+++ b/src/StarshipAscension.cpp
@@ -14,22 +14,22 @@ StarshipAscension::StarshipAscension(std::string name, std::string captain, std:
 {
 }
 
-void StarshipAscension::setX(int x)
+void StarshipAscension::setX(const uint32_t x)
 {
     m_x = x;
 }
 
-int StarshipAscension::getX() const
+uint32_t StarshipAscension::getX() const
 {
     return m_x;
 }
 
-int StarshipAscension::getY() const
+uint32_t StarshipAscension::getY() const
 {
     return m_y;
 }
 
-void StarshipAscension::setY(int y)
+void StarshipAscension::setY(const uint32_t y)
 {
     m_y = y;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -68,8 +68,8 @@ void Game::initializePlayingField() {
     for (int i = 0; i < NUM_STARBASES; i++) {
         Vector2D pos;
         do {
-            pos.x_ = rand() % PLAYING_FIELD_WIDTH;
-            pos.y_ = rand() % PLAYING_FIELD_HEIGHT;
+            pos.x = rand() % PLAYING_FIELD_WIDTH;
+            pos.y = rand() % PLAYING_FIELD_HEIGHT;
         } while (playingField.getObject(pos) != nullptr);
 
         // Starbase class needs to be implemented and derived from gameObj
@@ -79,8 +79,8 @@ void Game::initializePlayingField() {
     for (int i = 0; i < NUM_MOONS; i++) {
         Vector2D pos;
         do {
-            pos.x_ = rand() % PLAYING_FIELD_WIDTH;
-            pos.y_ = rand() % PLAYING_FIELD_HEIGHT;
+            pos.x = rand() % PLAYING_FIELD_WIDTH;
+            pos.y = rand() % PLAYING_FIELD_HEIGHT;
         } while (playingField.getObject(pos) != nullptr);
 
         // Use planet class here when it's implemented.
@@ -89,8 +89,8 @@ void Game::initializePlayingField() {
     for (int i = 0; i < NUM_ENEMY_SHIPS; i++) {
         Vector2D pos;
         do {
-            pos.x_ = rand() % PLAYING_FIELD_WIDTH;
-            pos.y_ = rand() % PLAYING_FIELD_HEIGHT;
+            pos.x = rand() % PLAYING_FIELD_WIDTH;
+            pos.y = rand() % PLAYING_FIELD_HEIGHT;
         } while (playingField.getObject(pos) != nullptr);
 
         Spaceship* enemy = new Spaceship("Enemy", 100, 100, 100);

--- a/src/include/Spaceship.h
+++ b/src/include/Spaceship.h
@@ -57,13 +57,13 @@ public:
 
 	Spaceship* Clone() const override;
 
-	int getX() const;
+	uint32_t getX() const;
 
-	void setX(int x);
+	void setX(const uint32_t x);
 
-	int getY() const;
+	uint32_t getY() const;
 
-	void setY(int y);
+	void setY(const uint32_t y);
 
 };
 

--- a/src/include/StarshipAscension.h
+++ b/src/include/StarshipAscension.h
@@ -1,6 +1,7 @@
 #ifndef SHIP_H
 #define SHIP_H
 
+#include <cstdint>
 #include <string>
 
 class Station;
@@ -9,13 +10,13 @@ class StarshipAscension {
 public:
     StarshipAscension(std::string name, std::string captain, std::string firstOfficer);
 
-    int getX() const;
+    uint32_t getX() const;
 
-    void setX(int x);
+    void setX(const uint32_t x);
 
-    int getY() const;
+    uint32_t getY() const;
 
-    void setY(int y);
+    void setY(const uint32_t y);
 
     int getMaxHealth() const;
 

--- a/src/include/docking_module.h
+++ b/src/include/docking_module.h
@@ -26,7 +26,7 @@ private:
 DockingModule::DockingModule() : docked_{ false }, station_{ nullptr } {}
 
 bool DockingModule::isDocked(Spaceship& spaceship) {
-    return docked_ && spaceship.getPos().x_ == station_->getX() && spaceship.getPos().y_ == station_->getY();
+    return docked_ && spaceship.getPos().x == station_->getX() && spaceship.getPos().y == station_->getY();
 }
 
 void DockingModule::dock(Spaceship& spaceship, Station& station) {

--- a/src/include/movement.h
+++ b/src/include/movement.h
@@ -9,19 +9,19 @@ class Movement
 public:
     Movement();
 
-    void moveUp(StarshipAscension& spaceship, int playingField[][PLAYING_FIELD_WIDTH]);
-    void moveLeft(StarshipAscension& spaceship, int playingField[][PLAYING_FIELD_WIDTH]);
-    void moveDown(StarshipAscension& spaceship, int playingField[][PLAYING_FIELD_WIDTH]);
-    void moveRight(StarshipAscension& spaceship, int playingField[][PLAYING_FIELD_WIDTH]);
+    void moveUp(StarshipAscension& spaceship, uint32_t playingField[][PLAYING_FIELD_WIDTH]);
+    void moveLeft(StarshipAscension& spaceship, uint32_t playingField[][PLAYING_FIELD_WIDTH]);
+    void moveDown(StarshipAscension& spaceship, uint32_t playingField[][PLAYING_FIELD_WIDTH]);
+    void moveRight(StarshipAscension& spaceship, uint32_t playingField[][PLAYING_FIELD_WIDTH]);
 
-    int getX() const;
-    void setX(int x);
-    int getY() const;
-    void setY(int y);
+    uint32_t getX() const;
+    void setX(const uint32_t x);
+    uint32_t getY() const;
+    void setY(const uint32_t y);
 
 private:
-    int m_x;
-    int m_y;
+    uint32_t m_x;
+    uint32_t m_y;
 
 };
 

--- a/src/include/playing_field.h
+++ b/src/include/playing_field.h
@@ -33,8 +33,8 @@ public:
 
 	void moveObject(GameObj* obj, int dx, int dy) {
     Vector2D newPos = obj->getPos() + Vector2D(dx, dy);
-    if (newPos.getX() < 0 || newPos.getX() >= PLAYING_FIELD_WIDTH ||
-        newPos.getY() < 0 || newPos.getY() >= PLAYING_FIELD_HEIGHT) {
+    if (newPos.x < 0 || newPos.x >= PLAYING_FIELD_WIDTH ||
+        newPos.y < 0 || newPos.y >= PLAYING_FIELD_HEIGHT) {
         return;
     }
     GameObj* otherObj = getObject(newPos);

--- a/src/include/station.h
+++ b/src/include/station.h
@@ -1,6 +1,7 @@
 #ifndef STATION_H
 #define STATION_H
 
+#include <cstdint>
 #include <string>
 
 class Spaceship;
@@ -19,10 +20,10 @@ public:
     void restock(Spaceship* spaceship, int amount);
     void restock(int amount);
     Station();
-    Station(int x, int y) : x_{ x }, y_{ y } {}
+    Station(uint32_t x, uint32_t y) : x_{ x }, y_{ y } {}
 
-    int getX() const { return x_; }
-    int getY() const { return y_; }
+    uint32_t getX() const { return x_; }
+    uint32_t getY() const { return y_; }
 
 private:
     std::string name_;
@@ -32,8 +33,8 @@ private:
     int maxHealth_;
     int maxFuel_;
     int maxAmmo_;
-    int x_;
-    int y_;
+    uint32_t x_;
+    uint32_t y_;
 };
 
 Station::Station() : x_{ 0 }, y_{ 0 } {}

--- a/src/include/vector2d.h
+++ b/src/include/vector2d.h
@@ -6,29 +6,25 @@
 class Vector2D
 {
 public:
-	int32_t x_;
-	int32_t y_;
+	int32_t x;
+	int32_t y;
 
-    Vector2D(uint32_t x, uint32_t y);
-    Vector2D(uint32_t scalar);
+    Vector2D(const int32_t x, const int32_t y);
+    explicit Vector2D(const int32_t scalar);
     Vector2D();
 
-	uint32_t getMagnitude() const;
-	uint32_t getMagnitudeSquared() const;
+	int32_t getMagnitude() const;
+	int32_t getMagnitudeSquared() const;
     Vector2D getNormalized() const;
     void normalize();
-
-	int32_t getX() const { return x_; } // added getX
-	int32_t getY() const { return y_; } // added getY
-
     Vector2D operator+(const Vector2D& other) const;
     Vector2D operator-(const Vector2D& other) const;
-    Vector2D operator*(uint32_t scalar) const;
-    Vector2D operator/(uint32_t scalar) const;
+    Vector2D operator*(const int32_t scalar) const;
+    Vector2D operator/(const int32_t scalar) const;
     Vector2D& operator+=(const Vector2D& other);
     Vector2D& operator-=(const Vector2D& other);
-    Vector2D& operator*=(uint32_t scalar);
-    Vector2D& operator/=(uint32_t scalar);
+    Vector2D& operator*=(const int32_t scalar);
+    Vector2D& operator/=(const int32_t scalar);
 	bool operator==(const Vector2D& other) const;
 	bool operator!=(const Vector2D& other) const;
 };

--- a/src/include/vector2d.h
+++ b/src/include/vector2d.h
@@ -6,25 +6,25 @@
 class Vector2D
 {
 public:
-	int32_t x;
-	int32_t y;
+	uint32_t x;
+	uint32_t y;
 
-    Vector2D(const int32_t x, const int32_t y);
-    explicit Vector2D(const int32_t scalar);
+    Vector2D(const uint32_t x, const uint32_t y);
+    explicit Vector2D(const uint32_t scalar);
     Vector2D();
 
-	int32_t getMagnitude() const;
-	int32_t getMagnitudeSquared() const;
+	uint32_t getMagnitude() const;
+	uint32_t getMagnitudeSquared() const;
     Vector2D getNormalized() const;
     void normalize();
     Vector2D operator+(const Vector2D& other) const;
     Vector2D operator-(const Vector2D& other) const;
-    Vector2D operator*(const int32_t scalar) const;
-    Vector2D operator/(const int32_t scalar) const;
+    Vector2D operator*(const uint32_t scalar) const;
+    Vector2D operator/(const uint32_t scalar) const;
     Vector2D& operator+=(const Vector2D& other);
     Vector2D& operator-=(const Vector2D& other);
-    Vector2D& operator*=(const int32_t scalar);
-    Vector2D& operator/=(const int32_t scalar);
+    Vector2D& operator*=(const uint32_t scalar);
+    Vector2D& operator/=(const uint32_t scalar);
 	bool operator==(const Vector2D& other) const;
 	bool operator!=(const Vector2D& other) const;
 };

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -10,48 +10,49 @@ Movement::Movement()
 }
 
 void Movement::moveUp(StarshipAscension& spaceship,
-                      int playingField[][PLAYING_FIELD_WIDTH]) {
+                      uint32_t playingField[][PLAYING_FIELD_WIDTH]) {
     if (spaceship.getY() > 0) {
         spaceship.setY(spaceship.getY() - 1);
     }
 }
 
 void Movement::moveLeft(StarshipAscension& spaceship,
-                        int playingField[][PLAYING_FIELD_WIDTH]) {
+                        uint32_t playingField[][PLAYING_FIELD_WIDTH]) {
     if (spaceship.getX() > 0) {
         spaceship.setX(spaceship.getX() - 1);
     }
 }
 
 void Movement::moveDown(StarshipAscension& spaceship,
-                        int playingField[][PLAYING_FIELD_WIDTH]) {
+                        uint32_t playingField[][PLAYING_FIELD_WIDTH]) {
     if (spaceship.getY() < PLAYING_FIELD_HEIGHT - 1) {
         spaceship.setY(spaceship.getY() + 1);
     }
 }
 
 void Movement::moveRight(StarshipAscension& spaceship,
-                         int playingField[][PLAYING_FIELD_WIDTH]) {
+                         uint32_t playingField[][PLAYING_FIELD_WIDTH]) {
     if (spaceship.getX() < PLAYING_FIELD_WIDTH - 1) {
         spaceship.setX(spaceship.getX() + 1);
     }
 }
-int Movement::getX() const
+
+uint32_t Movement::getX() const
 {
     return m_x;
 }
 
-void Movement::setX(int x)
+void Movement::setX(const uint32_t x)
 {
     m_x = x;
 }
 
-int Movement::getY() const
+uint32_t Movement::getY() const
 {
     return m_y;
 }
 
-void Movement::setY(int y)
+void Movement::setY(const uint32_t y)
 {
     m_y = y;
 }

--- a/src/vector2d.cpp
+++ b/src/vector2d.cpp
@@ -3,97 +3,97 @@
 #include <cmath>
 
 Vector2D::Vector2D()
-	: x_(0), y_(0)
+	: x(0), y(0)
 {
 }
 
-Vector2D::Vector2D(uint32_t x, uint32_t y)
-	: x_{x}, y_{y}
+Vector2D::Vector2D(const int32_t x, const int32_t y)
+	: x{x}, y{y}
 {
 }
 
-Vector2D::Vector2D(uint32_t scalar)
-	: x_(scalar), y_(scalar)
+Vector2D::Vector2D(const int32_t scalar)
+	: x(scalar), y(scalar)
 {
 }
 
-uint32_t Vector2D::getMagnitude() const
+int32_t Vector2D::getMagnitude() const
 {
-	return (uint32_t)std::sqrt((float)(x_ * x_ + y_ * y_));
+	return static_cast<int32_t>(std::sqrt(static_cast<float>(x * x + y * y)));
 }
 
-uint32_t Vector2D::getMagnitudeSquared() const
+int32_t Vector2D::getMagnitudeSquared() const
 {
-	return x_ * x_ + y_ * y_;
+	return x * x + y * y;
 }
 
 Vector2D Vector2D::getNormalized() const
 {
-	uint32_t magnitude = getMagnitude();
-    return {x_ / magnitude, y_ / magnitude};
+	const int32_t magnitude = getMagnitude();
+    return {x / magnitude, y / magnitude};
 }
 
 void Vector2D::normalize()
 {
-	uint32_t magnitude = getMagnitude();
-    x_ /= magnitude;
-    y_ /= magnitude;
+	const int32_t magnitude = getMagnitude();
+    x /= magnitude;
+    y /= magnitude;
 }
 
 Vector2D Vector2D::operator+(const Vector2D& other) const
 {
-    return {x_ + other.x_, y_ + other.y_};
+    return {x + other.x, y + other.y};
 }
 
 Vector2D Vector2D::operator-(const Vector2D& other) const
 {
-    return {x_ - other.x_, y_ - other.y_};
+    return {x - other.x, y - other.y};
 }
 
-Vector2D Vector2D::operator*(uint32_t scalar) const
+Vector2D Vector2D::operator*(const int32_t scalar) const
 {
-    return {x_ * scalar, y_ * scalar};
+    return {x * scalar, y * scalar};
 }
 
-Vector2D Vector2D::operator/(uint32_t scalar) const
+Vector2D Vector2D::operator/(const int32_t scalar) const
 {
-    return {x_ / scalar, y_ / scalar};
+    return {x / scalar, y / scalar};
 }
 
 Vector2D& Vector2D::operator+=(const Vector2D& other)
 {
-    x_ += other.x_;
-    y_ += other.y_;
+    x += other.x;
+    y += other.y;
     return *this;
 }
 
 Vector2D& Vector2D::operator-=(const Vector2D& other)
 {
-    x_ -= other.x_;
-    y_ -= other.y_;
+    x -= other.x;
+    y -= other.y;
     return *this;
 }
 
-Vector2D& Vector2D::operator*=(uint32_t scalar)
+Vector2D& Vector2D::operator*=(const int32_t scalar)
 {
-    x_ *= scalar;
-    y_ *= scalar;
+    x *= scalar;
+    y *= scalar;
     return *this;
 }
 
-Vector2D& Vector2D::operator/=(uint32_t scalar)
+Vector2D& Vector2D::operator/=(const int32_t scalar)
 {
-    x_ /= scalar;
-    y_ /= scalar;
+    x /= scalar;
+    y /= scalar;
     return *this;
 }
 
 bool Vector2D::operator==(const Vector2D& other) const
 {
-	return x_ == other.x_ && y_ == other.y_;
+	return x == other.x && y == other.y;
 }
 
 bool Vector2D::operator!=(const Vector2D& other) const
 {
-	return x_ != other.x_ || y_ != other.y_;
+	return x != other.x || y != other.y;
 }

--- a/src/vector2d.cpp
+++ b/src/vector2d.cpp
@@ -7,35 +7,35 @@ Vector2D::Vector2D()
 {
 }
 
-Vector2D::Vector2D(const int32_t x, const int32_t y)
+Vector2D::Vector2D(const uint32_t x, const uint32_t y)
 	: x{x}, y{y}
 {
 }
 
-Vector2D::Vector2D(const int32_t scalar)
+Vector2D::Vector2D(const uint32_t scalar)
 	: x(scalar), y(scalar)
 {
 }
 
-int32_t Vector2D::getMagnitude() const
+uint32_t Vector2D::getMagnitude() const
 {
-	return static_cast<int32_t>(std::sqrt(static_cast<float>(x * x + y * y)));
+	return static_cast<uint32_t>(std::sqrt(static_cast<float>(x * x + y * y)));
 }
 
-int32_t Vector2D::getMagnitudeSquared() const
+uint32_t Vector2D::getMagnitudeSquared() const
 {
 	return x * x + y * y;
 }
 
 Vector2D Vector2D::getNormalized() const
 {
-	const int32_t magnitude = getMagnitude();
+	const uint32_t magnitude = getMagnitude();
     return {x / magnitude, y / magnitude};
 }
 
 void Vector2D::normalize()
 {
-	const int32_t magnitude = getMagnitude();
+	const uint32_t magnitude = getMagnitude();
     x /= magnitude;
     y /= magnitude;
 }
@@ -50,12 +50,12 @@ Vector2D Vector2D::operator-(const Vector2D& other) const
     return {x - other.x, y - other.y};
 }
 
-Vector2D Vector2D::operator*(const int32_t scalar) const
+Vector2D Vector2D::operator*(const uint32_t scalar) const
 {
     return {x * scalar, y * scalar};
 }
 
-Vector2D Vector2D::operator/(const int32_t scalar) const
+Vector2D Vector2D::operator/(const uint32_t scalar) const
 {
     return {x / scalar, y / scalar};
 }
@@ -74,14 +74,14 @@ Vector2D& Vector2D::operator-=(const Vector2D& other)
     return *this;
 }
 
-Vector2D& Vector2D::operator*=(const int32_t scalar)
+Vector2D& Vector2D::operator*=(const uint32_t scalar)
 {
     x *= scalar;
     y *= scalar;
     return *this;
 }
 
-Vector2D& Vector2D::operator/=(const int32_t scalar)
+Vector2D& Vector2D::operator/=(const uint32_t scalar)
 {
     x /= scalar;
     y /= scalar;


### PR DESCRIPTION
Changed Vector2D internal type to be `uint32_t`, removed underscore from the `x` and `y` members, fixed the type mismatching in methods, removed `getX` and `getY` as they are not needed due to the two member variables being public.