### PR TITLE
Update .gitignore file for CMake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,16 +40,5 @@
 # debug information files
 *.dwo
 
-# CMake files
-CMakeLists.txt.user
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-Makefile
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-_deps
-CMakeUserPresets.json
+# files inside build directory
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,17 @@
 
 # debug information files
 *.dwo
+
+# CMake files
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json


### PR DESCRIPTION
@gbowne1 

I did this pull request to make the development of the StarshipAscension Game easier by adding useless CMake files to the .gitignore file of this repo.

What do you think about it?

Thanks.