### PR TITLE
Fix some errors in the file meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,8 +4,11 @@ project('StarshipAscension', 'cpp',
 
 inc = include_directories('include')
 
-exe = executable('StarshipAscension', 'src/main.cpp', 'src/game.cpp', 'src/util.cpp',
+glog_dep = dependency('glog', required: true)
+
+exe = executable('StarshipAscension', 'src/main.cpp', 'src/game.cpp', 'src/util.cpp', 'src/ship.cpp',
   include_directories : inc,
+  dependencies: [glog_dep],
   install : true)
 
 # For debug/release, use meson configure -Dbuildtype=debug or release


### PR DESCRIPTION
Hi, @gbowne1.

I have found some errors in the file meson.build:

- The file ship.cpp wasn't included in this file;
- The Google Logging Library wasn't used in the compilation process.

.

What do you think about this Pull Request?

Thanks.